### PR TITLE
Release: Text entry improvements (auto-scrolling)

### DIFF
--- a/App.xojo_code
+++ b/App.xojo_code
@@ -11,7 +11,6 @@ Inherits DesktopApplication
 		  
 		  W_DemoChatBubbles.Show
 		  
-		  
 		End Sub
 	#tag EndEvent
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+2023-06-06
+
+- When text is edited, the list box will scroll to the text insertion point
+- New public method to scroll to the insertion point: TRCustomListBox(instance).ScrollToInsertionPoint()
+- Refactored text metrics calculations
+- New public method to get the edit row TRCustomListBox(instance).EditRow() as TRCustomListBoxRow 
+- Bug fixes
+
 
 2023-06-03
 
@@ -7,9 +15,11 @@
 
 ![Chat Bubbles Demo](assets/Chat%20Bubbles.png)
 
+
 2023-06-02
 
 - Improve positioning of text when entering edit mode
+
 
 2023-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - New public method to scroll to the edit row's insertion point: TRCustomListBox(instance).ScrollToEditRowInsertionPoint()
 - Refactored text metrics calculations
 - New public method to get the edit row TRCustomListBox(instance).EditRow() as TRCustomListBoxRow 
-- New public method to inutively scroll to a content offset: TRProportionalDesktopScrollbar(instance)ScrollTo(value as Double, contentHeight as Double, visibleHeight as Double)
+- New public method to intuitively scroll to a content offset: TRProportionalDesktopScrollbar(instance)ScrollTo(value as Double, contentHeight as Double, visibleHeight as Double)
 - Bug fixes
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 2023-06-06
 
 - When text is edited, the list box will scroll to the text insertion point
-- New public method to scroll to the insertion point: TRCustomListBox(instance).ScrollToInsertionPoint()
+- New public method to scroll to the edit row's insertion point: TRCustomListBox(instance).ScrollToEditRowInsertionPoint()
 - Refactored text metrics calculations
 - New public method to get the edit row TRCustomListBox(instance).EditRow() as TRCustomListBoxRow 
+- New public method to inutively scroll to a content offset: TRProportionalDesktopScrollbar(instance)ScrollTo(value as Double, contentHeight as Double, visibleHeight as Double)
 - Bug fixes
 
 

--- a/Demos/Chat Bubbles/W_DemoChatBubbles.xojo_window
+++ b/Demos/Chat Bubbles/W_DemoChatBubbles.xojo_window
@@ -168,7 +168,7 @@ End
 		End Sub
 	#tag EndEvent
 	#tag Event
-		Sub WillEditRow(row as TRCustomListBoxRow)
+		Sub WillBeginEditRow(row as TRCustomListBoxRow)
 		  
 		  Me.CellTextArea.AllowSpellChecking = False
 		  Me.CellTextArea.ReadOnly = True

--- a/Demos/Chat Bubbles/W_DemoChatBubbles.xojo_window
+++ b/Demos/Chat Bubbles/W_DemoChatBubbles.xojo_window
@@ -168,7 +168,7 @@ End
 		End Sub
 	#tag EndEvent
 	#tag Event
-		Sub WillBeginEditRow(row as TRCustomListBoxRow)
+		Sub RowEditingWillBegin(row as TRCustomListBoxRow)
 		  
 		  Me.CellTextArea.AllowSpellChecking = False
 		  Me.CellTextArea.ReadOnly = True

--- a/Demos/W_DemoWonderland.xojo_window
+++ b/Demos/W_DemoWonderland.xojo_window
@@ -152,7 +152,7 @@ End
 
 #tag Events TRCLB_Demo
 	#tag Event
-		Sub WillEditRow(row as TRCustomListBoxRow)
+		Sub WillBeginEditRow(row as TRCustomListBoxRow)
 		  
 		  Me.DeselectAll
 		  

--- a/Demos/W_DemoWonderland.xojo_window
+++ b/Demos/W_DemoWonderland.xojo_window
@@ -152,7 +152,7 @@ End
 
 #tag Events TRCLB_Demo
 	#tag Event
-		Sub WillBeginEditRow(row as TRCustomListBoxRow)
+		Sub RowEditingWillBegin(row as TRCustomListBoxRow)
 		  
 		  Me.DeselectAll
 		  

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -2,7 +2,7 @@
 <RBProject version="2023r1.1" FormatVersion="2" MinIDEVersion="20210300">
 <block type="DesktopWindow" ID="1261617151">
  <ObjName>TRCustomListBox</ObjName>
- <ObjContainerID>1534973951</ObjContainerID>
+ <ObjContainerID>91383807</ObjContainerID>
  <IsClass>1</IsClass>
  <Superclass>DesktopContainer</Superclass>
  <ItemFlags>1</ItemFlags>
@@ -657,13 +657,13 @@
   <ItemResult>Double</ItemResult>
  </Method>
  <Method>
-  <ItemName>ScrollToInsertionPoint</ItemName>
+  <ItemName>ScrollToEditRowInsertionPoint</ItemName>
   <Compatibility></Compatibility>
   <Visible>1</Visible>
   <PartID>525971455</PartID>
   <ItemSource>
    <TextEncoding>134217984</TextEncoding>
-   <SourceLine>Sub ScrollToInsertionPoint()</SourceLine>
+   <SourceLine>Sub ScrollToEditRowInsertionPoint()</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>If CellTextArea.Visible = False Then</SourceLine>
    <SourceLine>Return</SourceLine>
@@ -1361,7 +1361,7 @@
     <TextEncoding>134217984</TextEncoding>
     <SourceLine>Sub SelectionChanged()</SourceLine>
     <SourceLine></SourceLine>
-    <SourceLine>Self.ScrollToInsertionPoint</SourceLine>
+    <SourceLine>Self.ScrollToEditRowInsertionPoint</SourceLine>
     <SourceLine></SourceLine>
     <SourceLine>End Sub</SourceLine>
    </ItemSource>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -680,13 +680,15 @@
    <SourceLine>Dim lineHeight As Double = Self.RowLineHeight(row, g)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Self.ContentOffset.Y = Max(-yOfEditRow, Min(Self.ContentOffset.Y, -((yOfEditRow - Self.Height) + lineCount * lineHeight)))</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>VerticalScrollbar.ScrollTo(-Self.ContentOffset.Y, Me.Height, Me.ComputedTotalHeight)</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
   </ItemSource>
   <TextEncoding>134217984</TextEncoding>
   <AliasName></AliasName>
-  <ItemFlags>33</ItemFlags>
+  <ItemFlags>0</ItemFlags>
   <IsShared>0</IsShared>
   <ItemParams></ItemParams>
   <ItemResult></ItemResult>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -77,7 +77,7 @@
    <SourceLine></SourceLine>
    <SourceLine>Self.Update_ScrollToInsertionPoint</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Me.Update_TextArea_Location</SourceLine>
+   <SourceLine>Me.Update_TextArea_ForEditing_Location</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
   </ItemSource>
@@ -380,13 +380,13 @@
   <ItemResult></ItemResult>
  </Method>
  <Method>
-  <ItemName>Update_TextArea_Location</ItemName>
+  <ItemName>Update_TextArea_ForEditing_Location</ItemName>
   <Compatibility></Compatibility>
   <Visible>1</Visible>
   <PartID>1710737407</PartID>
   <ItemSource>
    <TextEncoding>134217984</TextEncoding>
-   <SourceLine>Sub Update_TextArea_Location()</SourceLine>
+   <SourceLine>Sub Update_TextArea_ForEditing_Location()</SourceLine>
    <SourceLine>Dim row As TRCustomListBoxRow = Me.EditRow</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>If row = Nil Then </SourceLine>
@@ -434,8 +434,8 @@
    <SourceLine>Return</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Self.Update_TextArea(CellTextArea, row)</SourceLine>
-   <SourceLine>Self.Update_TextArea_Location</SourceLine>
+   <SourceLine>Self.Update_TextArea_ForEditing(row)</SourceLine>
+   <SourceLine>Self.Update_TextArea_ForEditing_Location</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>RaiseEvent RowEditingWillBegin(row)</SourceLine>
    <SourceLine></SourceLine>
@@ -477,13 +477,14 @@
   <ItemResult>Double</ItemResult>
  </Method>
  <Method>
-  <ItemName>Update_TextArea</ItemName>
+  <ItemName>Update_TextArea_ForEditing</ItemName>
   <Compatibility></Compatibility>
   <Visible>1</Visible>
   <PartID>1709473791</PartID>
   <ItemSource>
    <TextEncoding>134217984</TextEncoding>
-   <SourceLine>Sub Update_TextArea(ta as DesktopTextArea, row as TRCustomListBoxRow)</SourceLine>
+   <SourceLine>Sub Update_TextArea_ForEditing(row as TRCustomListBoxRow)</SourceLine>
+   <SourceLine>Dim ta As DesktopTextArea = CellTextArea</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>ta.Text = row.Text</SourceLine>
    <SourceLine>ta.FontName = Me.RowFontName(row)</SourceLine>
@@ -492,7 +493,7 @@
    <SourceLine>ta.LineSpacing = row.LineSpacing</SourceLine>
    <SourceLine>ta.TextColor = Me.RowFontColor(row)</SourceLine>
    <SourceLine>ta.TextAlignment = row.TextAlignment</SourceLine>
-   <SourceLine>ta.MultiLine = row.Multiline</SourceLine>
+   <SourceLine>ta.MultiLine = row.Multiline Or row.WordWrap</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
   </ItemSource>
@@ -500,7 +501,7 @@
   <AliasName></AliasName>
   <ItemFlags>33</ItemFlags>
   <IsShared>0</IsShared>
-  <ItemParams>ta as DesktopTextArea, row as TRCustomListBoxRow</ItemParams>
+  <ItemParams>row as TRCustomListBoxRow</ItemParams>
   <ItemResult></ItemResult>
  </Method>
  <Method>
@@ -535,7 +536,7 @@
    <TextEncoding>134217984</TextEncoding>
    <SourceLine>Function InternalRenderControl(row as TRCustomListBoxRow) As DesktopTextArea</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Me.Update_TextArea_ForRendering(row)</SourceLine>
+   <SourceLine>Me.Update_TextArea_ForRendering(row, row.ComputedTextHeight)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Return Me.TA_RenderSource</SourceLine>
    <SourceLine></SourceLine>
@@ -669,7 +670,7 @@
    <SourceLine>Dim yOfEditRow As Double = Self.RowPositionY(row)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>// We can't use CellTextArea to compute the insertion point of the current row because of the .lineNumber() bug</SourceLine>
-   <SourceLine>Self.Update_TextArea_ForRendering(row)</SourceLine>
+   <SourceLine>Self.Update_TextArea_ForRendering(row, row.ComputedTextHeight)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim lineCount As Integer = TA_RenderSource.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 1) + 1</SourceLine>
    <SourceLine></SourceLine>
@@ -677,7 +678,6 @@
    <SourceLine>g.FontName = Self.RowFontName(row)</SourceLine>
    <SourceLine>g.FontSize = Self.RowFontSize(row)</SourceLine>
    <SourceLine>Dim lineHeight As Double = Self.RowLineHeight(row, g)</SourceLine>
-   <SourceLine></SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>'Self.ContentOffset.Y = -(yOfEditRow + lineCount * lineHeight)</SourceLine>
    <SourceLine>System.DebugLog("insertion line: " + Str(lineCount))</SourceLine>
@@ -699,24 +699,28 @@
   <PartID>2124556287</PartID>
   <ItemSource>
    <TextEncoding>134217984</TextEncoding>
-   <SourceLine>Sub Update_TextArea_ForRendering(row as TRCustomListBoxRow)</SourceLine>
+   <SourceLine>Sub Update_TextArea_ForRendering(row as TRCustomListBoxRow, height as Double = -1)</SourceLine>
+   <SourceLine>Dim ta As DesktopTextArea = TA_RenderSource</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>TA_RenderSource.Text = row.Text</SourceLine>
+   <SourceLine>ta.Text = row.Text</SourceLine>
    <SourceLine>If row.Multiline Then</SourceLine>
    <SourceLine>// Might be issue with right justification?</SourceLine>
-   <SourceLine>TA_RenderSource.Text = TA_RenderSource.Text + "  " // Add two characters to workaround this bug: https://tracker.xojo.com/xojoinc/xojo/-/issues/72962</SourceLine>
+   <SourceLine>ta.Text = ta.Text + "  " // Add two characters to workaround this bug: https://tracker.xojo.com/xojoinc/xojo/-/issues/72962</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>TA_RenderSource.FontName = Me.RowFontName(row)</SourceLine>
-   <SourceLine>TA_RenderSource.FontSize = Me.RowFontSize(row)</SourceLine>
-   <SourceLine>TA_RenderSource.LineHeight = row.LineHeight</SourceLine>
-   <SourceLine>TA_RenderSource.LineSpacing = row.LineSpacing</SourceLine>
-   <SourceLine>TA_RenderSource.TextColor = Me.RowFontColor(row)</SourceLine>
-   <SourceLine>TA_RenderSource.TextAlignment = row.TextAlignment</SourceLine>
-   <SourceLine>TA_RenderSource.MultiLine = row.Multiline</SourceLine>
+   <SourceLine>ta.FontName = Me.RowFontName(row)</SourceLine>
+   <SourceLine>ta.FontSize = Me.RowFontSize(row)</SourceLine>
+   <SourceLine>ta.LineHeight = row.LineHeight</SourceLine>
+   <SourceLine>ta.LineSpacing = row.LineSpacing</SourceLine>
+   <SourceLine>ta.TextColor = Me.RowFontColor(row)</SourceLine>
+   <SourceLine>ta.TextAlignment = row.TextAlignment</SourceLine>
+   <SourceLine>ta.MultiLine = row.Multiline Or row.WordWrap</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>TA_RenderSource.Width = Self.RowTextAreaWidth(row)</SourceLine>
+   <SourceLine>ta.Width = Self.RowTextAreaWidth(row)</SourceLine>
    <SourceLine></SourceLine>
+   <SourceLine>If height &gt; -1 Then</SourceLine>
+   <SourceLine>ta.Height = height</SourceLine>
+   <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
   </ItemSource>
@@ -724,7 +728,7 @@
   <AliasName></AliasName>
   <ItemFlags>33</ItemFlags>
   <IsShared>0</IsShared>
-  <ItemParams>row as TRCustomListBoxRow</ItemParams>
+  <ItemParams>row as TRCustomListBoxRow, height as Double = -1</ItemParams>
   <ItemResult></ItemResult>
  </Method>
  <Hook>
@@ -1224,9 +1228,7 @@
     <SourceLine>End</SourceLine>
     <SourceLine></SourceLine>
     <SourceLine>If i &lt;&gt; Self.EditedRowIndex Then // Don't draw edited row; there's a text area covering it</SourceLine>
-    <SourceLine>Self.Update_TextArea_ForRendering(row)</SourceLine>
-    <SourceLine>TA_RenderSource.Height = row.ComputedHeight</SourceLine>
-    <SourceLine>TA_RenderSource.MultiLine = row.WordWrap</SourceLine>
+    <SourceLine>Self.Update_TextArea_ForRendering(row, row.ComputedTextHeight)</SourceLine>
     <SourceLine></SourceLine>
     <SourceLine>TA_RenderSource.DrawInto(g, row.MarginLeft, row.MarginTop)</SourceLine>
     <SourceLine>End</SourceLine>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -2,7 +2,7 @@
 <RBProject version="2023r1.1" FormatVersion="2" MinIDEVersion="20210300">
 <block type="DesktopWindow" ID="1261617151">
  <ObjName>TRCustomListBox</ObjName>
- <ObjContainerID>1534973951</ObjContainerID>
+ <ObjContainerID>91383807</ObjContainerID>
  <IsClass>1</IsClass>
  <Superclass>DesktopContainer</Superclass>
  <ItemFlags>1</ItemFlags>
@@ -207,8 +207,6 @@
    <SourceLine>For i = 0 To Me.Rows.LastIndex</SourceLine>
    <SourceLine>Me.Rows(i).Selected = False</SourceLine>
    <SourceLine>Next</SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine>// TODO: Validate? Maybe send an event</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>If doRefresh Then</SourceLine>
    <SourceLine>C_Content.Refresh</SourceLine>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -75,7 +75,7 @@
    <SourceLine>Me.ContentOffset.Y = offsetY</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Self.Update_ScrollToInsertionPoint</SourceLine>
+   <SourceLine>Self.Update_ScrollToInsertionPoint // Primary handled by SelectionChanged in CellTextArea, but this will keep the insertion point visible as the control changes size, rows are inserted or deleted, etc.</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Me.Update_TextArea_ForEditing_Location</SourceLine>
    <SourceLine></SourceLine>
@@ -673,13 +673,15 @@
    <SourceLine>Self.Update_TextArea_ForRendering(row, row.ComputedTextHeight)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim lineCount As Integer = TA_RenderSource.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 1) + 1</SourceLine>
+   <SourceLine>lineCount = lineCount + 1 // Add extra line for new returns and a little extra space at bottom</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim g As Graphics = Self.FontCalculatorGraphics</SourceLine>
    <SourceLine>g.FontName = Self.RowFontName(row)</SourceLine>
    <SourceLine>g.FontSize = Self.RowFontSize(row)</SourceLine>
    <SourceLine>Dim lineHeight As Double = Self.RowLineHeight(row, g)</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>'Self.ContentOffset.Y = -(yOfEditRow + lineCount * lineHeight)</SourceLine>
+   <SourceLine>Self.ContentOffset.Y = Min(Self.ContentOffset.Y, -((yOfEditRow - Self.Height) + lineCount * lineHeight))</SourceLine>
+   <SourceLine></SourceLine>
    <SourceLine>System.DebugLog("insertion line: " + Str(lineCount))</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
@@ -1340,6 +1342,20 @@
     <SourceLine>VerticalScrollbar.Value = VerticalScrollbar.Value + VerticalScrollbar.LineStep * Sign(deltaY)</SourceLine>
     <SourceLine></SourceLine>
     <SourceLine>End Function</SourceLine>
+   </ItemSource>
+  </HookInstance>
+  <HookInstance>
+   <ItemName>SelectionChanged</ItemName>
+   <Compatibility></Compatibility>
+   <Visible>1</Visible>
+   <PartID>99256319</PartID>
+   <ItemSource>
+    <TextEncoding>134217984</TextEncoding>
+    <SourceLine>Sub SelectionChanged()</SourceLine>
+    <SourceLine></SourceLine>
+    <SourceLine>Self.Update_ScrollToInsertionPoint</SourceLine>
+    <SourceLine></SourceLine>
+    <SourceLine>End Sub</SourceLine>
    </ItemSource>
   </HookInstance>
  </ControlBehavior>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -663,7 +663,7 @@
   <PartID>525971455</PartID>
   <ItemSource>
    <TextEncoding>134217984</TextEncoding>
-   <SourceLine>Sub ScrollToEditRowInsertionPoint()</SourceLine>
+   <SourceLine>Sub ScrollToEditRowInsertionPoint(allowSpaceForTyping as Boolean = True)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>If CellTextArea.Visible = False Then</SourceLine>
    <SourceLine>Return</SourceLine>
@@ -677,14 +677,22 @@
    <SourceLine>// Compute line metrics</SourceLine>
    <SourceLine>Self.Update_TextArea_ForRendering(row, row.ComputedTextHeight) // We can't use CellTextArea to compute the insertion point of the current row because of the .lineNumber() bug</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Dim lineCount As Integer = TA_RenderSource.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 1) + 1</SourceLine>
+   <SourceLine>Dim lineCount As Integer = TA_RenderSource.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 2) + 1 // + 2 because .LineNumber() will be glitchy when adding returns to the end of a text field; and since TA_RenderSource contains extra characters to work around this bug, we should use them to get the most accurate line count</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>System.DebugLog(Str(lineCount))</SourceLine>
+   <SourceLine></SourceLine>
    <SourceLine>Dim g As Graphics = Self.FontCalculatorGraphics</SourceLine>
    <SourceLine>g.FontName = Self.RowFontName(row)</SourceLine>
    <SourceLine>g.FontSize = Self.RowFontSize(row)</SourceLine>
    <SourceLine>Dim lineHeight As Double = Self.RowLineHeight(row, g)</SourceLine>
    <SourceLine></SourceLine>
+   <SourceLine>Dim extraLine As Integer = 0</SourceLine>
+   <SourceLine>If allowSpaceForTyping Then </SourceLine>
+   <SourceLine>extraLine = 1</SourceLine>
+   <SourceLine>End</SourceLine>
+   <SourceLine></SourceLine>
    <SourceLine>// Compute scroll targets</SourceLine>
-   <SourceLine>Dim yOffsetOfTargetRowBottomTarget As Double = (yOfEditRow - Self.Height + (lineCount + 1) * lineHeight) // lineCount + 1 to go to the line AFTER the current line (for new returns and a little extra space at the bottom)</SourceLine>
+   <SourceLine>Dim yOffsetOfTargetRowBottomTarget As Double = (yOfEditRow - Self.Height + (lineCount + extraLine) * lineHeight) // lineCount + 1 to go to the line AFTER the current line (for new returns and a little extra space at the bottom)</SourceLine>
    <SourceLine>Dim yOffsetOfTargetRowTopTarget As Double = (yOfEditRow + (lineCount - 1) * lineHeight) // lineCount - 1 to go to the line BEFORE the current line</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>// Set scroll targets in content pixels</SourceLine>
@@ -699,7 +707,7 @@
   <AliasName></AliasName>
   <ItemFlags>0</ItemFlags>
   <IsShared>0</IsShared>
-  <ItemParams></ItemParams>
+  <ItemParams>allowSpaceForTyping as Boolean = True</ItemParams>
   <ItemResult></ItemResult>
  </Method>
  <Method>
@@ -1332,6 +1340,8 @@
     <SourceLine>Self.Update_ComputeHeight_Row(row, Self.FontCalculatorGraphics)</SourceLine>
     <SourceLine>Self.ComputedTotalHeight = Self.ComputedTotalHeight - beforeHeight + row.ComputedHeight</SourceLine>
     <SourceLine></SourceLine>
+    <SourceLine>Self.ScrollToEditRowInsertionPoint(True)</SourceLine>
+    <SourceLine></SourceLine>
     <SourceLine>Self.Update(True)</SourceLine>
     <SourceLine>Self.Refresh(True)</SourceLine>
     <SourceLine></SourceLine>
@@ -1361,7 +1371,7 @@
     <TextEncoding>134217984</TextEncoding>
     <SourceLine>Sub SelectionChanged()</SourceLine>
     <SourceLine></SourceLine>
-    <SourceLine>Self.ScrollToEditRowInsertionPoint</SourceLine>
+    <SourceLine>Self.ScrollToEditRowInsertionPoint(False)</SourceLine>
     <SourceLine></SourceLine>
     <SourceLine>End Sub</SourceLine>
    </ItemSource>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -583,6 +583,9 @@
    <SourceLine>Dim row As TRCustomListBoxRow = Me.EditRow</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>CellTextArea.Visible = False</SourceLine>
+   <SourceLine>CellTextArea.SelectionStart = 0</SourceLine>
+   <SourceLine>CellTextArea.SelectionLength = 0</SourceLine>
+   <SourceLine></SourceLine>
    <SourceLine>Me.EditedRowIndex = -1</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>If row &lt;&gt; Nil Then</SourceLine>
@@ -662,6 +665,10 @@
    <TextEncoding>134217984</TextEncoding>
    <SourceLine>Sub ScrollToInsertionPoint()</SourceLine>
    <SourceLine></SourceLine>
+   <SourceLine>If CellTextArea.Visible = False Then</SourceLine>
+   <SourceLine>Return</SourceLine>
+   <SourceLine>End</SourceLine>
+   <SourceLine></SourceLine>
    <SourceLine>Dim row As TRCustomListBoxRow = Me.EditRow</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>If row &lt;&gt; Nil Then</SourceLine>
@@ -681,8 +688,7 @@
    <SourceLine>Dim yOffsetOfTargetRowTopTarget As Double = (yOfEditRow + (lineCount - 1) * lineHeight) // lineCount - 1 to go to the line BEFORE the current line</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>// Set scroll targets in content pixels</SourceLine>
-   <SourceLine>Self.ContentOffset.Y = Min(Self.ContentOffset.Y, -yOffsetOfTargetRowBottomTarget)</SourceLine>
-   <SourceLine>Self.ContentOffset.Y = Max(-yOffsetOfTargetRowTopTarget, Self.ContentOffset.Y)</SourceLine>
+   <SourceLine>Self.ContentOffset.Y = Min(-yOffsetOfTargetRowBottomTarget, Max(Self.ContentOffset.Y, -yOffsetOfTargetRowTopTarget))</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>VerticalScrollbar.ScrollTo(-Self.ContentOffset.Y, Me.Height, Me.ComputedTotalHeight)</SourceLine>
    <SourceLine>End</SourceLine>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -2,7 +2,7 @@
 <RBProject version="2023r1.1" FormatVersion="2" MinIDEVersion="20210300">
 <block type="DesktopWindow" ID="1261617151">
  <ObjName>TRCustomListBox</ObjName>
- <ObjContainerID>91383807</ObjContainerID>
+ <ObjContainerID>1534973951</ObjContainerID>
  <IsClass>1</IsClass>
  <Superclass>DesktopContainer</Superclass>
  <ItemFlags>1</ItemFlags>
@@ -209,8 +209,6 @@
    <SourceLine>Next</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>// TODO: Validate? Maybe send an event</SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine>CellTextArea.Visible = False</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>If doRefresh Then</SourceLine>
    <SourceLine>C_Content.Refresh</SourceLine>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -75,8 +75,6 @@
    <SourceLine>Me.ContentOffset.Y = offsetY</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Self.Update_ScrollToInsertionPoint // Primary handled by SelectionChanged in CellTextArea, but this will keep the insertion point visible as the control changes size, rows are inserted or deleted, etc.</SourceLine>
-   <SourceLine></SourceLine>
    <SourceLine>Me.Update_TextArea_ForEditing_Location</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
@@ -656,13 +654,13 @@
   <ItemResult>Double</ItemResult>
  </Method>
  <Method>
-  <ItemName>Update_ScrollToInsertionPoint</ItemName>
+  <ItemName>ScrollToInsertionPoint</ItemName>
   <Compatibility></Compatibility>
   <Visible>1</Visible>
   <PartID>525971455</PartID>
   <ItemSource>
    <TextEncoding>134217984</TextEncoding>
-   <SourceLine>Sub Update_ScrollToInsertionPoint()</SourceLine>
+   <SourceLine>Sub ScrollToInsertionPoint()</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim row As TRCustomListBoxRow = Me.EditRow</SourceLine>
    <SourceLine></SourceLine>
@@ -673,6 +671,7 @@
    <SourceLine>Self.Update_TextArea_ForRendering(row, row.ComputedTextHeight)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim lineCount As Integer = TA_RenderSource.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 1) + 1</SourceLine>
+   <SourceLine>' System.DebugLog("insertion line: " + Str(lineCount))</SourceLine>
    <SourceLine>lineCount = lineCount + 1 // Add extra line for new returns and a little extra space at bottom</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim g As Graphics = Self.FontCalculatorGraphics</SourceLine>
@@ -680,9 +679,7 @@
    <SourceLine>g.FontSize = Self.RowFontSize(row)</SourceLine>
    <SourceLine>Dim lineHeight As Double = Self.RowLineHeight(row, g)</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Self.ContentOffset.Y = Min(Self.ContentOffset.Y, -((yOfEditRow - Self.Height) + lineCount * lineHeight))</SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine>System.DebugLog("insertion line: " + Str(lineCount))</SourceLine>
+   <SourceLine>Self.ContentOffset.Y = Max(-yOfEditRow, Min(Self.ContentOffset.Y, -((yOfEditRow - Self.Height) + lineCount * lineHeight)))</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
@@ -1353,7 +1350,7 @@
     <TextEncoding>134217984</TextEncoding>
     <SourceLine>Sub SelectionChanged()</SourceLine>
     <SourceLine></SourceLine>
-    <SourceLine>Self.Update_ScrollToInsertionPoint</SourceLine>
+    <SourceLine>Self.ScrollToInsertionPoint</SourceLine>
     <SourceLine></SourceLine>
     <SourceLine>End Sub</SourceLine>
    </ItemSource>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -75,6 +75,8 @@
    <SourceLine>Me.ContentOffset.Y = offsetY</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
+   <SourceLine>Self.Update_ScrollToInsertionPoint</SourceLine>
+   <SourceLine></SourceLine>
    <SourceLine>Me.Update_TextArea_Location</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
@@ -631,6 +633,67 @@
   <IsShared>0</IsShared>
   <ItemParams></ItemParams>
   <ItemResult>TRCustomListBoxRow</ItemResult>
+ </Method>
+ <Method>
+  <ItemName>RowPositionY</ItemName>
+  <Compatibility></Compatibility>
+  <Visible>1</Visible>
+  <PartID>160923647</PartID>
+  <ItemSource>
+   <TextEncoding>134217984</TextEncoding>
+   <SourceLine>Function RowPositionY(row as TRCustomListBoxRow) As Double</SourceLine>
+   <SourceLine>Dim runningY As Double</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>For Each r As TRCustomListBoxRow In Self.Rows</SourceLine>
+   <SourceLine>If r = row Then</SourceLine>
+   <SourceLine>Return runningY</SourceLine>
+   <SourceLine>End</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>runningY = runningY + r.ComputedHeight</SourceLine>
+   <SourceLine>Next</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>Return -1</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>End Function</SourceLine>
+  </ItemSource>
+  <TextEncoding>134217984</TextEncoding>
+  <AliasName></AliasName>
+  <ItemFlags>0</ItemFlags>
+  <IsShared>0</IsShared>
+  <ItemParams>row as TRCustomListBoxRow</ItemParams>
+  <ItemResult>Double</ItemResult>
+ </Method>
+ <Method>
+  <ItemName>Update_ScrollToInsertionPoint</ItemName>
+  <Compatibility></Compatibility>
+  <Visible>1</Visible>
+  <PartID>525971455</PartID>
+  <ItemSource>
+   <TextEncoding>134217984</TextEncoding>
+   <SourceLine>Sub Update_ScrollToInsertionPoint()</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>Dim row As TRCustomListBoxRow = Me.EditRow</SourceLine>
+   <SourceLine>If row &lt;&gt; Nil Then</SourceLine>
+   <SourceLine>Dim yOfEditRow As Double = Self.RowPositionY(row)</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>'Me.ContentOffset.Y = -yOfEditRow</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>Dim lineIndex As Integer = CellTextArea.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 1)</SourceLine>
+   <SourceLine>Dim lineHeight As Double = Self.row</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>System.DebugLog("inseration line: " )</SourceLine>
+   <SourceLine>End</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>End Sub</SourceLine>
+  </ItemSource>
+  <TextEncoding>134217984</TextEncoding>
+  <AliasName></AliasName>
+  <ItemFlags>33</ItemFlags>
+  <IsShared>0</IsShared>
+  <ItemParams></ItemParams>
+  <ItemResult></ItemResult>
  </Method>
  <Hook>
   <ItemName>Resizing</ItemName>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -143,6 +143,7 @@
    <SourceLine>End</SourceLine>
    <SourceLine>Next</SourceLine>
    <SourceLine></SourceLine>
+   <SourceLine>Me.EditRowEnd</SourceLine>
    <SourceLine>Me.DeselectAll(True)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Return // Not found</SourceLine>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -407,7 +407,7 @@
    <SourceLine>yOfEditedRow = yOfEditedRow + Me.Rows(i).ComputedHeight</SourceLine>
    <SourceLine>Next</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Dim row As TRCustomListBoxRow = Me.Rows(Me.EditedRowIndex)</SourceLine>
+   <SourceLine>Dim row As TRCustomListBoxRow = Me.Rows(Me.EditedRowIndex) // TODO: Replace with .EditRow()</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>CellTextArea.Top = yOfEditedRow + row.MarginTop</SourceLine>
    <SourceLine>CellTextArea.Left = row.MarginLeft - kTextAreaLeftMarginPoints</SourceLine>
@@ -438,7 +438,7 @@
    <SourceLine>Return</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Dim row As TRCustomListBoxRow = Me.Rows(rowIndex)</SourceLine>
+   <SourceLine>Dim row As TRCustomListBoxRow = Me.Rows(rowIndex) // TODO: Replace with .EditRow()</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Self.Update_TextArea(CellTextArea, row)</SourceLine>
    <SourceLine>Self.Update_TextArea_Location</SourceLine>
@@ -451,7 +451,7 @@
   </ItemSource>
   <TextEncoding>134217984</TextEncoding>
   <AliasName></AliasName>
-  <ItemFlags>0</ItemFlags>
+  <ItemFlags>33</ItemFlags>
   <IsShared>0</IsShared>
   <ItemParams>rowIndex as Integer</ItemParams>
   <ItemResult></ItemResult>
@@ -599,6 +599,30 @@
   <IsShared>0</IsShared>
   <ItemParams></ItemParams>
   <ItemResult></ItemResult>
+ </Method>
+ <Method>
+  <ItemName>EditRow</ItemName>
+  <Compatibility></Compatibility>
+  <Visible>1</Visible>
+  <PartID>298891263</PartID>
+  <ItemSource>
+   <TextEncoding>134217984</TextEncoding>
+   <SourceLine>Function EditRow() As TRCustomListBoxRow</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>If Self.EditedRowIndex &lt; 0 Then </SourceLine>
+   <SourceLine>Return Nil</SourceLine>
+   <SourceLine>End</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>Return Me.Rows(Me.EditedRowIndex)</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>End Function</SourceLine>
+  </ItemSource>
+  <TextEncoding>134217984</TextEncoding>
+  <AliasName></AliasName>
+  <ItemFlags>0</ItemFlags>
+  <IsShared>0</IsShared>
+  <ItemParams></ItemParams>
+  <ItemResult>TRCustomListBoxRow</ItemResult>
  </Method>
  <Hook>
   <ItemName>Resizing</ItemName>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -667,29 +667,22 @@
    <SourceLine>If row &lt;&gt; Nil Then</SourceLine>
    <SourceLine>Dim yOfEditRow As Double = Self.RowPositionY(row)</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>// We can't use CellTextArea to compute the insertion point of the current row because of the .lineNumber() bug</SourceLine>
-   <SourceLine>Self.Update_TextArea_ForRendering(row, row.ComputedTextHeight)</SourceLine>
+   <SourceLine>// Compute line metrics</SourceLine>
+   <SourceLine>Self.Update_TextArea_ForRendering(row, row.ComputedTextHeight) // We can't use CellTextArea to compute the insertion point of the current row because of the .lineNumber() bug</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim lineCount As Integer = TA_RenderSource.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 1) + 1</SourceLine>
-   <SourceLine>' System.DebugLog("insertion line: " + Str(lineCount))</SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine>'lineCount = lineCount + 1 // Add extra line for new returns and a little extra space at bottom</SourceLine>
-   <SourceLine></SourceLine>
    <SourceLine>Dim g As Graphics = Self.FontCalculatorGraphics</SourceLine>
    <SourceLine>g.FontName = Self.RowFontName(row)</SourceLine>
    <SourceLine>g.FontSize = Self.RowFontSize(row)</SourceLine>
    <SourceLine>Dim lineHeight As Double = Self.RowLineHeight(row, g)</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Dim yOffsetOfTargetRowMin As Double = (yOfEditRow - Self.Height + (lineCount + 1) * lineHeight)</SourceLine>
-   <SourceLine>Dim yOffsetOfTargetRowMax As Double = (yOfEditRow + (lineCount - 1) * lineHeight)</SourceLine>
+   <SourceLine>// Compute scroll targets</SourceLine>
+   <SourceLine>Dim yOffsetOfTargetRowBottomTarget As Double = (yOfEditRow - Self.Height + (lineCount + 1) * lineHeight) // lineCount + 1 to go to the line AFTER the current line (for new returns and a little extra space at the bottom)</SourceLine>
+   <SourceLine>Dim yOffsetOfTargetRowTopTarget As Double = (yOfEditRow + (lineCount - 1) * lineHeight) // lineCount - 1 to go to the line BEFORE the current line</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Self.ContentOffset.Y = Min(Self.ContentOffset.Y, -yOffsetOfTargetRowMin)</SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine>'System.DebugLog(Str(yOffsetOfTargetRowMin))</SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine>Self.ContentOffset.Y = Max(-yOffsetOfTargetRowMax, Self.ContentOffset.Y)</SourceLine>
-   <SourceLine>'Self.ContentOffset.Y = Max(-yOffsetOfTargetRow, Min(Self.ContentOffset.Y, -yOffsetOfTargetRow))</SourceLine>
+   <SourceLine>// Set scroll targets in content pixels</SourceLine>
+   <SourceLine>Self.ContentOffset.Y = Min(Self.ContentOffset.Y, -yOffsetOfTargetRowBottomTarget)</SourceLine>
+   <SourceLine>Self.ContentOffset.Y = Max(-yOffsetOfTargetRowTopTarget, Self.ContentOffset.Y)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>VerticalScrollbar.ScrollTo(-Self.ContentOffset.Y, Me.Height, Me.ComputedTotalHeight)</SourceLine>
    <SourceLine>End</SourceLine>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -2,7 +2,7 @@
 <RBProject version="2023r1.1" FormatVersion="2" MinIDEVersion="20210300">
 <block type="DesktopWindow" ID="1261617151">
  <ObjName>TRCustomListBox</ObjName>
- <ObjContainerID>91383807</ObjContainerID>
+ <ObjContainerID>1534973951</ObjContainerID>
  <IsClass>1</IsClass>
  <Superclass>DesktopContainer</Superclass>
  <ItemFlags>1</ItemFlags>
@@ -672,14 +672,24 @@
    <SourceLine></SourceLine>
    <SourceLine>Dim lineCount As Integer = TA_RenderSource.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 1) + 1</SourceLine>
    <SourceLine>' System.DebugLog("insertion line: " + Str(lineCount))</SourceLine>
-   <SourceLine>lineCount = lineCount + 1 // Add extra line for new returns and a little extra space at bottom</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>'lineCount = lineCount + 1 // Add extra line for new returns and a little extra space at bottom</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim g As Graphics = Self.FontCalculatorGraphics</SourceLine>
    <SourceLine>g.FontName = Self.RowFontName(row)</SourceLine>
    <SourceLine>g.FontSize = Self.RowFontSize(row)</SourceLine>
    <SourceLine>Dim lineHeight As Double = Self.RowLineHeight(row, g)</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Self.ContentOffset.Y = Max(-yOfEditRow, Min(Self.ContentOffset.Y, -((yOfEditRow - Self.Height) + lineCount * lineHeight)))</SourceLine>
+   <SourceLine>Dim yOffsetOfTargetRowMin As Double = (yOfEditRow - Self.Height + (lineCount + 1) * lineHeight)</SourceLine>
+   <SourceLine>Dim yOffsetOfTargetRowMax As Double = (yOfEditRow + (lineCount - 1) * lineHeight)</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>Self.ContentOffset.Y = Min(Self.ContentOffset.Y, -yOffsetOfTargetRowMin)</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>'System.DebugLog(Str(yOffsetOfTargetRowMin))</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>Self.ContentOffset.Y = Max(-yOffsetOfTargetRowMax, Self.ContentOffset.Y)</SourceLine>
+   <SourceLine>'Self.ContentOffset.Y = Max(-yOffsetOfTargetRow, Min(Self.ContentOffset.Y, -yOffsetOfTargetRow))</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>VerticalScrollbar.ScrollTo(-Self.ContentOffset.Y, Me.Height, Me.ComputedTotalHeight)</SourceLine>
    <SourceLine>End</SourceLine>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -446,7 +446,7 @@
    <SourceLine>Self.Update_TextArea(CellTextArea, row)</SourceLine>
    <SourceLine>Self.Update_TextArea_Location</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>RaiseEvent WillBeginEditRow(row)</SourceLine>
+   <SourceLine>RaiseEvent RowEditingWillBegin(row)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>CellTextArea.Visible = True</SourceLine>
    <SourceLine></SourceLine>
@@ -596,7 +596,7 @@
    <SourceLine>Me.EditedRowIndex = -1</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>If row &lt;&gt; Nil Then</SourceLine>
-   <SourceLine>RaiseEvent DidEndEditRow(row)</SourceLine>
+   <SourceLine>RaiseEvent RowEditingDidEnd(row)</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
@@ -641,7 +641,7 @@
   <ItemResult></ItemResult>
  </Hook>
  <Hook>
-  <ItemName>WillBeginEditRow</ItemName>
+  <ItemName>RowEditingWillBegin</ItemName>
   <TextEncoding>134217984</TextEncoding>
   <ItemFlags>33</ItemFlags>
   <SystemFlags>0</SystemFlags>
@@ -649,7 +649,7 @@
   <ItemResult></ItemResult>
  </Hook>
  <Hook>
-  <ItemName>DidEndEditRow</ItemName>
+  <ItemName>RowEditingDidEnd</ItemName>
   <TextEncoding>134217984</TextEncoding>
   <ItemFlags>33</ItemFlags>
   <SystemFlags>0</SystemFlags>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -446,7 +446,7 @@
    <SourceLine>Self.Update_TextArea(CellTextArea, row)</SourceLine>
    <SourceLine>Self.Update_TextArea_Location</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>RaiseEvent WillEditRow(row)</SourceLine>
+   <SourceLine>RaiseEvent WillBeginEditRow(row)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>CellTextArea.Visible = True</SourceLine>
    <SourceLine></SourceLine>
@@ -590,9 +590,14 @@
   <ItemSource>
    <TextEncoding>134217984</TextEncoding>
    <SourceLine>Sub EditRowEnd()</SourceLine>
+   <SourceLine>Dim row As TRCustomListBoxRow = Me.EditRow</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>CellTextArea.Visible = False</SourceLine>
    <SourceLine>Me.EditedRowIndex = -1</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>If row &lt;&gt; Nil Then</SourceLine>
+   <SourceLine>RaiseEvent DidEndEditRow(row)</SourceLine>
+   <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
   </ItemSource>
@@ -636,7 +641,15 @@
   <ItemResult></ItemResult>
  </Hook>
  <Hook>
-  <ItemName>WillEditRow</ItemName>
+  <ItemName>WillBeginEditRow</ItemName>
+  <TextEncoding>134217984</TextEncoding>
+  <ItemFlags>33</ItemFlags>
+  <SystemFlags>0</SystemFlags>
+  <ItemParams>row as TRCustomListBoxRow</ItemParams>
+  <ItemResult></ItemResult>
+ </Hook>
+ <Hook>
+  <ItemName>DidEndEditRow</ItemName>
   <TextEncoding>134217984</TextEncoding>
   <ItemFlags>33</ItemFlags>
   <SystemFlags>0</SystemFlags>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -396,8 +396,9 @@
   <ItemSource>
    <TextEncoding>134217984</TextEncoding>
    <SourceLine>Sub Update_TextArea_Location()</SourceLine>
+   <SourceLine>Dim row As TRCustomListBoxRow = Me.EditRow</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>If Self.EditedRowIndex &lt; 0 Then </SourceLine>
+   <SourceLine>If row = Nil Then </SourceLine>
    <SourceLine>Return</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
@@ -407,8 +408,6 @@
    <SourceLine>For i = 0 To Self.EditedRowIndex-1</SourceLine>
    <SourceLine>yOfEditedRow = yOfEditedRow + Me.Rows(i).ComputedHeight</SourceLine>
    <SourceLine>Next</SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine>Dim row As TRCustomListBoxRow = Me.Rows(Me.EditedRowIndex) // TODO: Replace with .EditRow()</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>CellTextArea.Top = yOfEditedRow + row.MarginTop</SourceLine>
    <SourceLine>CellTextArea.Left = row.MarginLeft - kTextAreaLeftMarginPoints</SourceLine>
@@ -434,12 +433,15 @@
    <SourceLine></SourceLine>
    <SourceLine>Self.EditedRowIndex = rowIndex</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>If Self.EditedRowIndex &lt; 0 Then</SourceLine>
+   <SourceLine>Dim row As TRCustomListBoxRow = Me.EditRow</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>If row = Nil Then </SourceLine>
    <SourceLine>CellTextArea.Visible = False</SourceLine>
-   <SourceLine>Return</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Dim row As TRCustomListBoxRow = Me.Rows(rowIndex) // TODO: Replace with .EditRow()</SourceLine>
+   <SourceLine>If Self.EditedRowIndex &lt; 0 Then</SourceLine>
+   <SourceLine>Return</SourceLine>
+   <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Self.Update_TextArea(CellTextArea, row)</SourceLine>
    <SourceLine>Self.Update_TextArea_Location</SourceLine>

--- a/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
+++ b/Tinrocket Common/TRCustomListbox/TRCustomListBox.xojo_xml_code
@@ -287,7 +287,7 @@
   <PartID>1915854847</PartID>
   <ItemSource>
    <TextEncoding>134217984</TextEncoding>
-   <SourceLine>Function RowLineHeight(row as TRCustomListBoxRow, fontName as String, fontSize as Double) As Double</SourceLine>
+   <SourceLine>Function RowLineHeight(row as TRCustomListBoxRow, g as Graphics) As Double</SourceLine>
    <SourceLine>#Pragma BackgroundTasks False</SourceLine>
    <SourceLine>#Pragma StackOverflowChecking False</SourceLine>
    <SourceLine>#Pragma NilObjectChecking False</SourceLine>
@@ -297,11 +297,6 @@
    <SourceLine>Return row.LineHeight</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Dim g As Graphics = Me.FontCalculatorGraphics</SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine>g.FontName = fontName</SourceLine>
-   <SourceLine>g.FontSize = fontSize</SourceLine>
-   <SourceLine></SourceLine>
    <SourceLine>Return g.TextHeight * row.LineSpacing</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Function</SourceLine>
@@ -310,7 +305,7 @@
   <AliasName></AliasName>
   <ItemFlags>33</ItemFlags>
   <IsShared>0</IsShared>
-  <ItemParams>row as TRCustomListBoxRow, fontName as String, fontSize as Double</ItemParams>
+  <ItemParams>row as TRCustomListBoxRow, g as Graphics</ItemParams>
   <ItemResult>Double</ItemResult>
  </Method>
  <Method>
@@ -363,15 +358,9 @@
    <SourceLine>Else</SourceLine>
    <SourceLine>g.FontName = Self.RowFontName(row)</SourceLine>
    <SourceLine>g.FontSize = Self.RowFontSize(row)</SourceLine>
-   <SourceLine>lineHeight = Self.RowLineHeight(row, g.FontName, g.FontSize)</SourceLine>
+   <SourceLine>lineHeight = Self.RowLineHeight(row, g)</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Self.Update_TextArea(TA_RenderSource, row)</SourceLine>
-   <SourceLine>TA_RenderSource.Width = Self.RowTextAreaWidth(row)</SourceLine>
-   <SourceLine></SourceLine>
-   <SourceLine>If row.Multiline Then</SourceLine>
-   <SourceLine>// Might be issue with right justification?</SourceLine>
-   <SourceLine>TA_RenderSource.Text = TA_RenderSource.Text + "  " // Add two characters to workaround this bug: https://tracker.xojo.com/xojoinc/xojo/-/issues/72962</SourceLine>
-   <SourceLine>End</SourceLine>
+   <SourceLine>Self.Update_TextArea_ForRendering(row)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim lineCount As Integer = TA_RenderSource.LineNumber(TA_RenderSource.Text.Length) + 1</SourceLine>
    <SourceLine></SourceLine>
@@ -546,7 +535,7 @@
    <TextEncoding>134217984</TextEncoding>
    <SourceLine>Function InternalRenderControl(row as TRCustomListBoxRow) As DesktopTextArea</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Me.Update_TextArea(TA_RenderSource, row)</SourceLine>
+   <SourceLine>Me.Update_TextArea_ForRendering(row)</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Return Me.TA_RenderSource</SourceLine>
    <SourceLine></SourceLine>
@@ -675,15 +664,23 @@
    <SourceLine>Sub Update_ScrollToInsertionPoint()</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>Dim row As TRCustomListBoxRow = Me.EditRow</SourceLine>
+   <SourceLine></SourceLine>
    <SourceLine>If row &lt;&gt; Nil Then</SourceLine>
    <SourceLine>Dim yOfEditRow As Double = Self.RowPositionY(row)</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>'Me.ContentOffset.Y = -yOfEditRow</SourceLine>
+   <SourceLine>// We can't use CellTextArea to compute the insertion point of the current row because of the .lineNumber() bug</SourceLine>
+   <SourceLine>Self.Update_TextArea_ForRendering(row)</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>Dim lineIndex As Integer = CellTextArea.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 1)</SourceLine>
-   <SourceLine>Dim lineHeight As Double = Self.row</SourceLine>
+   <SourceLine>Dim lineCount As Integer = TA_RenderSource.LineNumber(CellTextArea.SelectionStart + CellTextArea.SelectionLength + 1) + 1</SourceLine>
    <SourceLine></SourceLine>
-   <SourceLine>System.DebugLog("inseration line: " )</SourceLine>
+   <SourceLine>Dim g As Graphics = Self.FontCalculatorGraphics</SourceLine>
+   <SourceLine>g.FontName = Self.RowFontName(row)</SourceLine>
+   <SourceLine>g.FontSize = Self.RowFontSize(row)</SourceLine>
+   <SourceLine>Dim lineHeight As Double = Self.RowLineHeight(row, g)</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>'Self.ContentOffset.Y = -(yOfEditRow + lineCount * lineHeight)</SourceLine>
+   <SourceLine>System.DebugLog("insertion line: " + Str(lineCount))</SourceLine>
    <SourceLine>End</SourceLine>
    <SourceLine></SourceLine>
    <SourceLine>End Sub</SourceLine>
@@ -693,6 +690,41 @@
   <ItemFlags>33</ItemFlags>
   <IsShared>0</IsShared>
   <ItemParams></ItemParams>
+  <ItemResult></ItemResult>
+ </Method>
+ <Method>
+  <ItemName>Update_TextArea_ForRendering</ItemName>
+  <Compatibility></Compatibility>
+  <Visible>1</Visible>
+  <PartID>2124556287</PartID>
+  <ItemSource>
+   <TextEncoding>134217984</TextEncoding>
+   <SourceLine>Sub Update_TextArea_ForRendering(row as TRCustomListBoxRow)</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>TA_RenderSource.Text = row.Text</SourceLine>
+   <SourceLine>If row.Multiline Then</SourceLine>
+   <SourceLine>// Might be issue with right justification?</SourceLine>
+   <SourceLine>TA_RenderSource.Text = TA_RenderSource.Text + "  " // Add two characters to workaround this bug: https://tracker.xojo.com/xojoinc/xojo/-/issues/72962</SourceLine>
+   <SourceLine>End</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>TA_RenderSource.FontName = Me.RowFontName(row)</SourceLine>
+   <SourceLine>TA_RenderSource.FontSize = Me.RowFontSize(row)</SourceLine>
+   <SourceLine>TA_RenderSource.LineHeight = row.LineHeight</SourceLine>
+   <SourceLine>TA_RenderSource.LineSpacing = row.LineSpacing</SourceLine>
+   <SourceLine>TA_RenderSource.TextColor = Me.RowFontColor(row)</SourceLine>
+   <SourceLine>TA_RenderSource.TextAlignment = row.TextAlignment</SourceLine>
+   <SourceLine>TA_RenderSource.MultiLine = row.Multiline</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>TA_RenderSource.Width = Self.RowTextAreaWidth(row)</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>End Sub</SourceLine>
+  </ItemSource>
+  <TextEncoding>134217984</TextEncoding>
+  <AliasName></AliasName>
+  <ItemFlags>33</ItemFlags>
+  <IsShared>0</IsShared>
+  <ItemParams>row as TRCustomListBoxRow</ItemParams>
   <ItemResult></ItemResult>
  </Method>
  <Hook>
@@ -1192,10 +1224,8 @@
     <SourceLine>End</SourceLine>
     <SourceLine></SourceLine>
     <SourceLine>If i &lt;&gt; Self.EditedRowIndex Then // Don't draw edited row; there's a text area covering it</SourceLine>
-    <SourceLine>Self.Update_TextArea(TA_RenderSource, row)</SourceLine>
-    <SourceLine></SourceLine>
+    <SourceLine>Self.Update_TextArea_ForRendering(row)</SourceLine>
     <SourceLine>TA_RenderSource.Height = row.ComputedHeight</SourceLine>
-    <SourceLine>TA_RenderSource.Width = Self.RowTextAreaWidth(row)</SourceLine>
     <SourceLine>TA_RenderSource.MultiLine = row.WordWrap</SourceLine>
     <SourceLine></SourceLine>
     <SourceLine>TA_RenderSource.DrawInto(g, row.MarginLeft, row.MarginTop)</SourceLine>

--- a/Tinrocket Common/TRProportionalDesktopScrollbar.xojo_xml_code
+++ b/Tinrocket Common/TRProportionalDesktopScrollbar.xojo_xml_code
@@ -40,6 +40,27 @@
   <ItemParams>contentSize as Double, visibleSize as Double</ItemParams>
   <ItemResult>Double</ItemResult>
  </Method>
+ <Method>
+  <ItemName>ScrollTo</ItemName>
+  <Compatibility></Compatibility>
+  <Visible>1</Visible>
+  <PartID>217796607</PartID>
+  <ItemSource>
+   <TextEncoding>134217984</TextEncoding>
+   <SourceLine>Sub ScrollTo(value as Double, contentHeight as Double, visibleHeight as Double)</SourceLine>
+   <SourceLine>Dim scrollFraction As Double = value / (visibleHeight - contentHeight)</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>Me.Value = scrollFraction * Me.MaximumValue</SourceLine>
+   <SourceLine></SourceLine>
+   <SourceLine>End Sub</SourceLine>
+  </ItemSource>
+  <TextEncoding>134217984</TextEncoding>
+  <AliasName></AliasName>
+  <ItemFlags>0</ItemFlags>
+  <IsShared>0</IsShared>
+  <ItemParams>value as Double, contentHeight as Double, visibleHeight as Double</ItemParams>
+  <ItemResult></ItemResult>
+ </Method>
  <Property>
   <ItemName>AutoHide</ItemName>
   <Compatibility></Compatibility>


### PR DESCRIPTION
- When text is edited, the list box will scroll to the text insertion point
- New public method to scroll to the edit row's insertion point: TRCustomListBox(instance).ScrollToEditRowInsertionPoint()
- Refactored text metrics calculations
- New public method to get the edit row TRCustomListBox(instance).EditRow() as TRCustomListBoxRow 
- New public method to intuitively scroll to a content offset: TRProportionalDesktopScrollbar(instance)ScrollTo(value as Double, contentHeight as Double, visibleHeight as Double)
- Bug fixes

TRCustomListBox works around a verified XOJO bug when measuring the lines in a TextArea. Getting an accurate count of the number of lines of text in a TextArea is critical to this control's functionality:

https://tracker.xojo.com/xojoinc/xojo/-/issues/72962#note_556234

However, it would make things better (simpler, faster) if XOJO fixed this bug in a future release. Please consider upvoting the issue.